### PR TITLE
for duplicates keep the last column, usually not empty

### DIFF
--- a/src/financial_statement.py
+++ b/src/financial_statement.py
@@ -48,7 +48,7 @@ class FinancialStatement:
             df['ticker'] = ticker
             ticker = df.pop('ticker')
             df.insert(0, 'ticker', ticker)
-            df = df.loc[:,~df.columns.duplicated()]
+            df = df.loc[:,~df.columns.duplicated(keep='last')]
             return df
         except ValueError:
             pass


### PR DESCRIPTION
Avoiding Null in json for available data in Excel.
Example: 
for "current inventories", the value will be Null if not saving the last column from the duplicates.